### PR TITLE
Using Timeout.timeout as timeout is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-### Install
+# Sensu Check JMX Jolokia
+
+This is the updated and improved version of inokappa's [sensu-plugin-check-jmx-jolokia](https://github.com/inokappa/sensu-plugin-check-jmx-jolokia) plugin. This version has been updated to use the new Timeout function introduced in later versions of Sensu. It also allows checking MBeans which return Strings. 
+*This plugin requires [Jolokia](https://jolokia.org/) to be running on the host machine, exposing the JMX beans that you want to monitor.
+
+## Install
 
 Put to your sensu plugins directory.
 
@@ -7,14 +12,14 @@ sudo cp check-jmx-jolokia.rb /etc/sensu/plugins/
 sudo chmod 755 /etc/sensu/plugins/check-jmx-jolokia.rb
 ~~~
 
-### how to use
+## Usage
 
 ~~~bash
-$ ./check-jmx-jolokia.rb -u http://127.0.0.1:8778 -m "java.lang:type=Memory" -a "HeapMemoryUsage" -i used -k value -w 10 -c -100
+$ ./check-jmx-jolokia.rb -u http://127.0.0.1:8778 -m "java.lang:type=Memory" -a "HeapMemoryUsage" -i "used" -k "value" -w 10 -c -100
 CheckJmxJolokia CRITICAL: HeapMemoryUsage used value => 31215760
 ~~~
 
-### example jolokia response
+## Example
 
 ~~~bash
 $ curl -s http://127.0.0.1:8778/jolokia/read/java.lang:type=Memory/HeapMemoryUsage/used | jq .

--- a/check-jmx-jolokia.rb
+++ b/check-jmx-jolokia.rb
@@ -30,7 +30,7 @@ class CheckJmxJolokia < Sensu::Plugin::Check::CLI
     end
 
     begin
-      timeout(config[:timeout]) do
+      Timeout.timeout(config[:timeout]) do
         get_resource
       end
     rescue Timeout::Error

--- a/check-jmx-jolokia.rb
+++ b/check-jmx-jolokia.rb
@@ -1,22 +1,54 @@
 #!/usr/bin/env ruby
 #
+#   sensu-checks-jmx-jolokia
+#
+# DESCRIPTION:
+#   Allows monitoring of JMX beans which have been exposed via Jolokia
+#
+# OUTPUT:
+#   plain text, integer
+#
+# PLATFORMS:
+#   Linux, Windows, macOS
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#   ./check-jmx-jolokia.rb -u http://127.0.0.1:8778 -m "java.lang:type=Memory" -a "HeapMemoryUsage" -i used -k value -w 10 -c -100
+#
+# NOTES:
+#   This can ONLY be used in situations where Jolokia is running on the target machine and exposing the JMX beans
+#
+# LICENSE:
+#   Lewis England <lewis2004@outlook.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'json'
 require 'net/http'
 
+class String
+  def is_integer?
+    self.to_i.to_s == self
+  end
+end
+
 class CheckJmxJolokia < Sensu::Plugin::Check::CLI
 
-  option :url, :short => '-u URL'
-  option :host, :short => '-h HOST'
-  option :path, :short => '-p PATH', :default => '/jolokia/read'
-  option :timeout, :short => '-t SECS', :proc => proc { |a| a.to_i }, :default => 15
-  option :mbean, :short => '-m Mbean', :long => '--mbean Mbean'
-  option :attribute, :short => '-a Attribute', :long => '--attribute VALUE'
-  option :innner_path, :short => '-i Inner PATH', :long => '--innner-path Inner PATH'
-  option :json_key, :short => '-k KEY', :long => '--key KEY'
-  option :crit, :short => '-c VALUE', :long => '--critical VALUE'
-  option :warn, :short => '-w VALUE', :long => '--warning VALUE'
+  option :url, :short => '-u URL', :default => 'http://127.0.0.1:8778' :description => 'The base URL to connect to (including port)'
+  option :host, :short => '-h HOST', :default => 'localhost', :description => '(Optional) The name of the host to connect to'
+  option :path, :short => '-p PATH', :default => '/jolokia/read', :description => 'The URL path to the base of Jolokia'
+  option :timeout, :short => '-t SECS', :proc => proc { |a| a.to_i }, :default => 15, :description => 'URL request timeout, in seconds'
+  option :mbean, :short => '-m Mbean', :long => '--mbean Mbean', :description => 'Name of the MBean to query'
+  option :attribute, :short => '-a Attribute', :long => '--attribute VALUE', :description => 'Name of the MBean attribute to query'
+  option :innner_path, :short => '-i Inner PATH', :long => '--innner-path Inner PATH', :description => '(Optional) The inner path of the MBean attribute'
+  option :json_key, :short => '-k KEY', :long => '--key KEY', :description => 'Name of the MBean attribute\'s key to query'
+  option :crit, :short => '-c VALUE', :long => '--critical VALUE', :description => 'The CRITICAL state. Can be a string to match to or a integer threshold'
+  option :warn, :short => '-w VALUE', :long => '--warning VALUE', :description => 'The WARNING state. Can be a string to match to or a integer threshold'
 
   def run
     if config[:url]
@@ -62,9 +94,17 @@ class CheckJmxJolokia < Sensu::Plugin::Check::CLI
     when /^2/
       if json_valid?(res.body)
         json = JSON.parse(res.body)
-        critical "#{msg} #{json[config[:json_key]].to_i}" if json[config[:json_key]].to_i > config[:crit].to_i
-        warning "#{msg} #{json[config[:json_key]].to_i}" if json[config[:json_key]].to_i > config[:warn].to_i
-        ok "#{msg} #{json[config[:json_key]].to_i}"
+        if config[:warn].is_integer?
+          warning "#{msg} #{json[config[:json_key]].to_i}" if json[config[:json_key]].to_i > config[:warn].to_i
+        else
+          warning "#{msg} #{json[config[:json_key]]}" if json[config[:json_key]] == config[:warn]
+        end
+        if config[:crit].is_integer?
+          critical "#{msg} #{json[config[:json_key]].to_i}" if json[config[:json_key]].to_i > config[:crit].to_i
+        else
+          critical "#{msg} #{json[config[:json_key]]}" if json[config[:json_key]] == config[:crit]
+        end
+        ok "#{msg} #{json[config[:json_key]]}"
       else
         critical "Response contains invalid JSON."
       end


### PR DESCRIPTION
Upgrading to Sensu 0.26.0 causes errors as `timeout` has been deprecated
